### PR TITLE
Set Content Request Type

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,6 +94,7 @@ Instapaper.prototype.request = function(endpoint, body, callback) {
                 opts.oauth_token        = oauth.token;
                 opts.oauth_token_secret = oauth.secret;
                 opts.url                = this.opts.apiUrl + endpoint;
+                opts.type               = 'application/x-www-form-urlencoded';
 
                 logger.debug('making API request', opts);
                 return this.POST(opts);


### PR DESCRIPTION
Because it's not optional
https://github.com/Mashape/mashape-oauth/issues/27